### PR TITLE
0.0.14: fix import path

### DIFF
--- a/projects/shared/src/lib/pipes/dimless.pipe.ts
+++ b/projects/shared/src/lib/pipes/dimless.pipe.ts
@@ -1,5 +1,5 @@
 import { Pipe, PipeTransform } from '@angular/core';
-import { FormatterService } from '~/services/formatter.service';
+import { FormatterService } from '../services/formatter.service';
 
 @Pipe({
   name: 'dimless',


### PR DESCRIPTION
After merging https://github.com/ivoalmeida/ceph-ui/pull/2, I see below error on starting the MCM app -

```
Page reload sent to client(s).
✘ [ERROR] Could not resolve "~/services/formatter.service"

    node_modules/@ceph-ui/shared/fesm2022/ceph-ui-shared.mjs:28:22:
      28 │ import * as i1$1 from '~/services/formatter.service';
         ╵                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

  You can mark the path "~/services/formatter.service" as external to exclude it from the bundle,
  which will remove this error and leave the unresolved path in the bundle.
```
