### PR TITLE
0.0.15: fix side panel imports

### DIFF
--- a/projects/shared/src/lib/components/side-panel/side-panel.component.ts
+++ b/projects/shared/src/lib/components/side-panel/side-panel.component.ts
@@ -1,3 +1,4 @@
+import { CommonModule } from '@angular/common';
 import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { ButtonModule, IconModule, PanelModule } from 'carbon-components-angular';
 
@@ -9,7 +10,8 @@ import { ButtonModule, IconModule, PanelModule } from 'carbon-components-angular
   imports: [
     PanelModule,
     ButtonModule,
-    IconModule
+    IconModule,
+    CommonModule
   ]
 })
 export class SidePanelComponent {


### PR DESCRIPTION
Getting this error on using the side panel component

`Can't bind to 'ngIf' since it isn't a known property of 'div' (used in the '_SidePanelComponent' component template).`